### PR TITLE
Adding a snippet to publish Themes

### DIFF
--- a/Themes/PublishTheme.ps1
+++ b/Themes/PublishTheme.ps1
@@ -1,0 +1,11 @@
+# The following snippet will retrieve a Theme ID by name, and publish the theme.
+# This can be useful to automate deplyoments, as themes are not part of solutions. 
+
+# Fetch Theme ID by name
+$themeId = (Get-CrmRecords -EntityLogicalName theme -FilterAttribute name -FilterOperator eq -FilterValue "CRM Blue Theme").CrmRecords[0].themeid
+
+# Create reference to theme entity for the publish action
+$theme = New-CrmEntityReference -EntityLogicalName theme -Id $themeId
+
+# Publish Theme (https://docs.microsoft.com/en-us/dynamics365/customer-engagement/web-api/publishtheme?view=dynamics-ce-odata-9)
+Invoke-CrmAction -Name "PublishTheme" -Parameters @{Target = $theme;}


### PR DESCRIPTION
A theme id will be retrieved by a given name and published. This can be useful to automate deplyoments, as themes are not part of solutions.